### PR TITLE
[FE] design: Board List item font-size 수정

### DIFF
--- a/client/src/components/Board/BoardAuthorInfo.tsx
+++ b/client/src/components/Board/BoardAuthorInfo.tsx
@@ -12,7 +12,7 @@ interface BoardAuthorInfoProps {
 function BoardAuthorInfo({ userName, userImage, date }: BoardAuthorInfoProps) {
   return (
     <BoardAuthorInfoContainer>
-      {userImage ? <img src={userImage} alt="userImage" /> : <FaUserCircle />}
+      {userImage ? <img src={userImage} alt='userImage' /> : <FaUserCircle />}
       <BoardAuthorInfoName>
         {userName}
         <p>{convertTime(date)}</p>
@@ -29,6 +29,12 @@ const BoardAuthorInfoContainer = styled.div`
   padding-bottom: var(--small);
   display: flex;
   align-items: center;
+
+  > img {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+  }
 
   > svg {
     width: 40px;

--- a/client/src/components/Board/BoardContents.tsx
+++ b/client/src/components/Board/BoardContents.tsx
@@ -25,12 +25,19 @@ const BoardContentsContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: top;
+
+  @media only screen and (max-width: 768px) {
+    margin: var(--x-small) 0;
+  }
 `;
 
 const BoardContentsTitle = styled.div`
   margin-bottom: var(--x-small);
   font-size: var(--text-large);
   font-weight: var(--weight-large);
+  @media only screen and (max-width: 768px) {
+    font-size: 4vw;
+  }
 `;
 
 const BoardContentsBody = styled.div`
@@ -40,4 +47,13 @@ const BoardContentsBody = styled.div`
   font-size: var(--text-small);
   font-weight: var(--weight-x-small);
   overflow: hidden;
+  > div {
+    > div {
+      > p {
+        @media only screen and (max-width: 768px) {
+          font-size: 3vw !important;
+        }
+      }
+    }
+  }
 `;

--- a/client/src/components/Board/BoardContents.tsx
+++ b/client/src/components/Board/BoardContents.tsx
@@ -34,7 +34,10 @@ const BoardContentsTitle = styled.div`
 `;
 
 const BoardContentsBody = styled.div`
+  width: 100%;
+  height: 100px;
   line-height: var(--medium);
   font-size: var(--text-small);
   font-weight: var(--weight-x-small);
+  overflow: hidden;
 `;

--- a/client/src/components/Board/BoardItem.tsx
+++ b/client/src/components/Board/BoardItem.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-
+import { Link } from 'react-router-dom';
 import Card from '../UI/Card';
 import BoardContents from './BoardContents';
 import BoardMetaInfo from './BoardMetaInfo';
@@ -30,14 +30,14 @@ function BoardItem({ data }: BoardItemprops) {
     <MarginContainer>
       <Card>
         <ItemContainer>
-          <BoardAuthorInfo
-            userName={data.memberName}
-            userImage={data.profileImageUrl}
-            date={data.createdAt}
-          />
-
-          <BoardContents title={data.boardTitle} content={data.content} />
-
+          <Link to={`/board/detail/${data.boardId}`}>
+            <BoardAuthorInfo
+              userName={data.memberName}
+              userImage={data.profileImageUrl}
+              date={data.createdAt}
+            />
+            <BoardContents title={data.boardTitle} content={data.content} />
+          </Link>
           <BoardMetaInfo
             boardId={data.boardId}
             tags={data.tags}
@@ -57,6 +57,10 @@ const MarginContainer = styled.div`
   margin-bottom: calc(var(--4x-large) / 2);
   margin-right: var(--x-small);
   margin-left: var(--x-small);
+
+  @media only screen and (max-width: 768px) {
+    width: 100%;
+  }
 `;
 
 const ItemContainer = styled.div`
@@ -80,5 +84,6 @@ const ItemContainer = styled.div`
 
   > a {
     width: 100%;
+    max-width: 680px;
   }
 `;

--- a/client/src/components/Board/BoardItem.tsx
+++ b/client/src/components/Board/BoardItem.tsx
@@ -60,6 +60,7 @@ const MarginContainer = styled.div`
 
   @media only screen and (max-width: 768px) {
     width: 100%;
+    margin-bottom: calc(var(--2x-large) / 2);
   }
 `;
 
@@ -80,6 +81,7 @@ const ItemContainer = styled.div`
 
   @media only screen and (max-width: 768px) {
     width: 100%;
+    padding: var(--large);
   }
 
   > a {

--- a/client/src/components/Board/BoardItem.tsx
+++ b/client/src/components/Board/BoardItem.tsx
@@ -4,7 +4,6 @@ import Card from '../UI/Card';
 import BoardContents from './BoardContents';
 import BoardMetaInfo from './BoardMetaInfo';
 import BoardAuthorInfo from './BoardAuthorInfo';
-import { Link } from 'react-router-dom';
 
 interface BoardItemprops {
   data: {
@@ -36,9 +35,9 @@ function BoardItem({ data }: BoardItemprops) {
             userImage={data.profileImageUrl}
             date={data.createdAt}
           />
-          <Link to={`/board/detail/${data.boardId}`}>
-            <BoardContents title={data.boardTitle} content={data.content} />
-          </Link>
+
+          <BoardContents title={data.boardTitle} content={data.content} />
+
           <BoardMetaInfo
             boardId={data.boardId}
             tags={data.tags}

--- a/client/src/components/Board/BoardMetaInfo.tsx
+++ b/client/src/components/Board/BoardMetaInfo.tsx
@@ -1,7 +1,7 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
-import BoardStats from "./BoardStats";
-import BoardTags from "./BoardTags";
+import BoardStats from './BoardStats';
+import BoardTags from './BoardTags';
 
 interface BoardMetaInfoProps {
   boardId: number;

--- a/client/src/components/Board/BoardTag.tsx
+++ b/client/src/components/Board/BoardTag.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 interface BoardTagProps {
   tag: string;
@@ -27,11 +27,12 @@ const TagWrapper = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: var(--2x-small);
-    transition: .5s;
+    padding: var(--3x-small);
+    transition: 0.5s;
+    white-space: nowrap;
 
     &:hover {
-      transition: .5s;
+      transition: 0.5s;
       background-color: var(--color-main);
       color: var(--color-white);
       border: 1px solid var(--color-main);

--- a/client/src/components/Board/BoardTags.tsx
+++ b/client/src/components/Board/BoardTags.tsx
@@ -31,6 +31,10 @@ export default BoardTags;
 
 const TagsBox = styled.div`
   display: flex;
+  height: 25px;
+  @media only screen and (max-width: 768px) {
+    display: none;
+  }
 `;
 
 const TagsContainer = styled.div`

--- a/client/src/components/layout/BaseLayout.tsx
+++ b/client/src/components/layout/BaseLayout.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { Outlet } from "react-router-dom";
-import Header from "./Header/Header";
-import styled from "styled-components";
-import bowmore from "../../assets/img/bowmore.jpg";
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import Header from './Header/Header';
+import styled from 'styled-components';
+import bowmore from '../../assets/img/bowmore.jpg';
 
 interface MainLayoutProps {
   bgColor?: boolean;
@@ -26,7 +26,6 @@ function BaseLayout({ bgColor, img }: MainLayoutProps) {
           <Outlet />
         </Container>
       </ContainerBox>
-
     </DefaultSize>
   );
 }
@@ -34,7 +33,7 @@ function BaseLayout({ bgColor, img }: MainLayoutProps) {
 export default BaseLayout;
 
 const DefaultSize = styled.div<MainLayoutProps>`
-  width: 100%;
+  width: 100vw;
   height: auto;
   background-color: ${(props) =>
     props.bgColor ? `var(--color-sub-light-gray)` : `var(--color-main)`};
@@ -44,30 +43,30 @@ const DefaultSize = styled.div<MainLayoutProps>`
 `;
 
 const ContainerBox = styled.div<MainLayoutProps>`
-width: 100%;
-height: auto;
-background-image: ${(props) => (props.img ? `url(${bowmore})` : `none`)};
-background-repeat: no - repeat;
-background-size: cover;
-display: flex;
-justify-content: center;
-align-items: center;
-
-@media only screen and(max-width: 768px) {
   width: 100%;
-  background-position: 40% 50%;
+  height: auto;
+  background-image: ${(props) => (props.img ? `url(${bowmore})` : `none`)};
+  background-repeat: no - repeat;
   background-size: cover;
-}
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  @media only screen and(max-width: 768px) {
+    width: 100%;
+    background-position: 40% 50%;
+    background-size: cover;
+  }
 `;
 
 const Container = styled.div<MainLayoutProps>`
-color: var(--color - main);
-background-color: ${(props) =>
+  color: var(--color - main);
+  background-color: ${(props) =>
     props.img ? `none` : `var(--color-sub-light-gray)`};
-width: 85%;
-height: auto;
-max-width: 1420px;
-display: flex;
-align-items: center;
-justify-content: space-between;
+  width: 85%;
+  height: auto;
+  max-width: 1420px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `;

--- a/client/src/pages/BoardList.tsx
+++ b/client/src/pages/BoardList.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import axios from 'axios';
 import { useAppDispatch, useAppSelector } from '../redux/hooks/hooks';
@@ -58,11 +57,7 @@ function BoardList() {
           <BoardInfo search={search} setSearch={setSearch} />
           <ListContainer>
             {(filteredData.length === 0 ? isData : filteredData)?.map((el) => {
-              return (
-                <Link to={`/board/detail/${el.boardId}`}>
-                  <BoardItem key={el.boardId} data={el} />
-                </Link>
-              );
+              return <BoardItem key={el.boardId} data={el} />;
             })}
           </ListContainer>
         </Wrapper>
@@ -89,8 +84,8 @@ const ListContainer = styled.div`
   flex-wrap: wrap;
   justify-content: center;
 
-  @media only screen and (max-width: 768px) {
+  /* @media only screen and (max-width: 768px) {
     display: flex;
     justify-content: center;
-  }
+  } */
 `;

--- a/client/src/pages/BoardList.tsx
+++ b/client/src/pages/BoardList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import axios from 'axios';
 import { useAppDispatch, useAppSelector } from '../redux/hooks/hooks';
@@ -57,7 +58,11 @@ function BoardList() {
           <BoardInfo search={search} setSearch={setSearch} />
           <ListContainer>
             {(filteredData.length === 0 ? isData : filteredData)?.map((el) => {
-              return <BoardItem key={el.boardId} data={el} />;
+              return (
+                <Link to={`/board/detail/${el.boardId}`}>
+                  <BoardItem key={el.boardId} data={el} />
+                </Link>
+              );
             })}
           </ListContainer>
         </Wrapper>


### PR DESCRIPTION
## ✏️ Summary
- Board List Item content 높이 고정되게 수정
- Board List Item 반응형 너비 일정하게 수정
- Board List Item 반응형 font-size 수정



<br>

## 🔗 Describe your changes
- width가 320px일 때
![image](https://user-images.githubusercontent.com/115691844/228223001-3d32baf2-2db3-4f8b-b28f-045df4b35f7f.png)



<br>

## 💬 To Reviewers
- 이미지가 들어가도 item의 높이가 달라지지 않게 수정했습니다. 
- 반응형시 item의 너비가 tag의 갯수에 따라 달라지지 않게 수정했습니다.
- 반응형시 font-size가 반응형으로 바뀌도록 수정했습니다.