### PR TITLE
[FE] fix: Board Create tags Button 반응 없는 에러 수정

### DIFF
--- a/client/src/pages/BoardCreate.tsx
+++ b/client/src/pages/BoardCreate.tsx
@@ -59,6 +59,9 @@ function BoardCreate() {
           setPreData(item);
           setTags(item.tags);
           setBoardImageUrl(item.boardImageUrl);
+        } else {
+          localStorage.removeItem('editData');
+          editData();
         }
       } else {
         editData();
@@ -158,6 +161,7 @@ function BoardCreate() {
         axios
           .patch(`/boards/${editId}`, newBoard)
           .then((res) => {
+            localStorage.removeItem('editData');
             navigate('/board/list');
             alert('성공적으로 수정되었습니다.');
             window.location.reload();

--- a/client/src/pages/BoardCreate.tsx
+++ b/client/src/pages/BoardCreate.tsx
@@ -102,7 +102,7 @@ function BoardCreate() {
 
   const handleTagSearchOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    setSearchOpen(true);
+    setSearchOpen((prev) => !prev);
   };
   const handleTagSearchClose = () => {
     setSearchOpen(false);

--- a/client/src/redux/slice/board/boardListSlice.ts
+++ b/client/src/redux/slice/board/boardListSlice.ts
@@ -28,8 +28,17 @@ export const boardListSlice = createSlice({
         payload: { data, likeList },
       }: PayloadAction<{ data: BoardDataProps[]; likeList: ILikeList[] }>
     ) => {
+      const result = data.map((board: BoardDataProps) => {
+        return {
+          ...board,
+          like: likeList.some(
+            (el: { boardId: number; boardTitle: string }) =>
+              el.boardId === board.boardId
+          ),
+        };
+      });
       state.likeList = likeList;
-      const NotData = data.reduce((acc: BoardDataProps[], cur) => {
+      const NotData = result.reduce((acc: BoardDataProps[], cur) => {
         let result: BoardDataProps[] = [...acc];
         if (
           state.listData.filter((el) => cur.boardId === el.boardId).length === 0


### PR DESCRIPTION
## ✏️ Summary
- Board List Like 표시 안되는 에러 수정
- Board Edit 임시 저장 불러오기 취소해도 데이터가 남아있는 오류 수정
- Board Create tags Button 반응 없는 에러 수정

<br>

## 💬 To Reviewers
- Board List page에서 자신이 Like 한지 안 한지 표시 안되는 에러 수정했습니다.
- Board Edit 임시 저장 불러오기 취소하면 임시 저장 데이터 삭제되도록 수정했습니다.
-  Board Create tags search 모달창이 띄워져 있을 때 tags Button을 누르면 모달창이 닫히게 수정했습니다. 