### PR TITLE
[FE] fix: Board Detail recommend like 적용 안되는 버그 수정

### DIFF
--- a/client/src/components/Article/ArticleDetail/articledetailcontent/ArticleDetailBody.tsx
+++ b/client/src/components/Article/ArticleDetail/articledetailcontent/ArticleDetailBody.tsx
@@ -11,11 +11,12 @@ function ArticleDetailBody({ content }: props) {
   return (
     <MainContainer>
       {content.includes('http') ? (
-        <img src={`${content}`} alt="drinkImg"></img>
+        <img src={`${content}`} alt='drinkImg'></img>
       ) : (
         <ReactMarkdown
           children={content}
-          remarkPlugins={[remarkGfm]}></ReactMarkdown>
+          remarkPlugins={[remarkGfm]}
+        ></ReactMarkdown>
       )}
     </MainContainer>
   );

--- a/client/src/components/Board/BoardDetailContents.tsx
+++ b/client/src/components/Board/BoardDetailContents.tsx
@@ -1,14 +1,18 @@
 import styled from 'styled-components';
 import '@toast-ui/editor/dist/toastui-editor-viewer.css';
-import { Viewer } from '@toast-ui/react-editor';
 import { useAppSelector } from '../../redux/hooks/hooks';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 function BoardDetailContents() {
   const { content } = useAppSelector((state) => state.boardDetail.detailData);
 
   return (
     <ContentsContainer>
-      <Viewer initialValue={content || ''} />
+      <ReactMarkdown
+        children={content}
+        remarkPlugins={[remarkGfm]}
+      ></ReactMarkdown>
     </ContentsContainer>
   );
 }
@@ -19,6 +23,9 @@ const ContentsContainer = styled.div`
   font-size: var(--text-medium);
   line-height: var(--large);
   margin-bottom: var(--4x-large);
+  img {
+    max-width: 100%;
+  }
 
   @media only screen and (max-width: 768px) {
     margin-bottom: var(--large);

--- a/client/src/components/Board/BoardItem.tsx
+++ b/client/src/components/Board/BoardItem.tsx
@@ -17,7 +17,7 @@ interface BoardItemprops {
       tagId: number;
       tagName: string;
     }>;
-    like?: boolean;
+    like: boolean;
     likeCount: number;
     commentCount: number;
     createdAt: string;

--- a/client/src/components/Board/BoardLikes.tsx
+++ b/client/src/components/Board/BoardLikes.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { useAppDispatch } from '../../redux/hooks/hooks';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import axios from 'axios';
 
 import { IoMdHeartEmpty, IoMdHeart } from 'react-icons/io';
@@ -16,12 +16,16 @@ import {
 interface BoardLikesProps {
   boardId: number;
   like?: number;
-  likes?: boolean;
+  likes: boolean;
 }
 
 function BoardLikes({ like, likes, boardId }: BoardLikesProps) {
-  const [isLike, setIsLike] = useState(likes);
+  const [isLike, setIsLike] = useState(false);
   const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    setIsLike(likes);
+  }, [likes]);
 
   const handleLikeChange = () => {
     if (isLike) {

--- a/client/src/components/Board/BoardMetaInfo.tsx
+++ b/client/src/components/Board/BoardMetaInfo.tsx
@@ -10,7 +10,7 @@ interface BoardMetaInfoProps {
     tagName: string;
   }>;
   like: number;
-  likes?: boolean;
+  likes: boolean;
   comment: number;
 }
 

--- a/client/src/components/Board/BoardStats.tsx
+++ b/client/src/components/Board/BoardStats.tsx
@@ -1,12 +1,12 @@
-import styled from "styled-components";
-import BoardLikes from "./BoardLikes";
-import BoardComments from "./BoardComments";
+import styled from 'styled-components';
+import BoardLikes from './BoardLikes';
+import BoardComments from './BoardComments';
 
 interface BoardStatsProps {
   boardId: number;
   like: number;
   comment: number;
-  likes?: boolean;
+  likes: boolean;
 }
 
 function BoardStats({ like, comment, likes, boardId }: BoardStatsProps) {

--- a/client/src/pages/BoardCreate.tsx
+++ b/client/src/pages/BoardCreate.tsx
@@ -41,7 +41,7 @@ function BoardCreate() {
       const res = await axios.get(`/boards/${editId}`);
       setIsEditData((prev) => res.data);
       setTags((prev) => res.data.tags);
-      setBoardImageUrl((prev) => res.data.boardImageUrl);
+      setBoardImageUrl((prev) => res.data.boardImages);
     };
     const getItem = localStorage.getItem('data');
     const getEditItem = localStorage.getItem('editData');
@@ -132,6 +132,7 @@ function BoardCreate() {
     imageId: number;
     boardImageUrl: string;
   }) => {
+    console.log(boardImageUrl);
     setBoardImageUrl((prev) => [...prev, url]);
   };
 

--- a/client/src/redux/slice/board/boardDetail.ts
+++ b/client/src/redux/slice/board/boardDetail.ts
@@ -6,12 +6,12 @@ import { Data, ILikeList } from '../../../util/interfaces/boards.interface';
 interface boardDetailState {
   detailData: {
     [key: string]: any;
-    like?: boolean;
+    like: boolean;
   };
 }
 
 const initialState: boardDetailState = {
-  detailData: {},
+  detailData: { like: false },
 };
 
 export const boardDetailSlice = createSlice({


### PR DESCRIPTION
## ✏️ Summary
- [x] Board Edit 이미지 추가 에러 수정
- [x] Board Detail recommend 내용 변경 불가 에러 수정
- [x] Board Detail recommend like 적용 안되는 버그 수정

<br>

## 💬 To Reviewers
- 불러오는 데이터 객체의 key를 잘못 작성해서 Board Edit시 이미지가 추가 되지 않는 에러를 수정했습니다.
- Board Detail recommend 클릭 시 전 Board의 내용이 들어가는 에러를 수정했습니다.
-  Board Detail recommend 클릭 시 전 Board의 like 상태가 유지되는 에러를 수정했습니다.
