### PR TITLE
[FE] feat: Drink Detail Like post, delete 기능 구현

### DIFF
--- a/client/src/components/Drinks/DrinksDetail/DrinksDetailItem.tsx
+++ b/client/src/components/Drinks/DrinksDetail/DrinksDetailItem.tsx
@@ -1,15 +1,14 @@
-import React from "react";
-import styled from "styled-components";
-import DrinksDetailImg from "./drinksdetaillitem/DrinksDetailImg";
-import DrinksDetailTxt from "./drinksdetaillitem/DrinksDetailTxt";
-import { IDrinksDetailProps } from '../../../util/interfaces/drinks.inerface'
+import React from 'react';
+import styled from 'styled-components';
+import DrinksDetailImg from './drinksdetaillitem/DrinksDetailImg';
+import DrinksDetailTxt from './drinksdetaillitem/DrinksDetailTxt';
+import { IDrinksDetailLike } from '../../../util/interfaces/drinks.inerface';
 
-function DrinksDetailItem({ drinksDetail }: IDrinksDetailProps) {
-
+function DrinksDetailItem({ drinksDetail, drinksLike }: IDrinksDetailLike) {
   return (
     <ItemContainer>
       <DrinksDetailImg drinksDetail={drinksDetail} />
-      <DrinksDetailTxt drinksDetail={drinksDetail} />
+      <DrinksDetailTxt drinksDetail={drinksDetail} drinksLike={drinksLike} />
     </ItemContainer>
   );
 }

--- a/client/src/components/Drinks/DrinksDetail/MainDrinksDetail.tsx
+++ b/client/src/components/Drinks/DrinksDetail/MainDrinksDetail.tsx
@@ -1,14 +1,14 @@
-import React from "react";
-import styled from "styled-components";
-import DrinksDetailComment from "./DrinksDetailComment";
-import DrinksDetailContent from "./DrinksDetailContent";
-import DrinksDetailItem from "./DrinksDetailItem";
-import { IDrinksDetailProps } from "../../../util/interfaces/drinks.inerface";
+import React from 'react';
+import styled from 'styled-components';
+import DrinksDetailComment from './DrinksDetailComment';
+import DrinksDetailContent from './DrinksDetailContent';
+import DrinksDetailItem from './DrinksDetailItem';
+import { IDrinksDetailLike } from '../../../util/interfaces/drinks.inerface';
 
-function MainDrinksDetail({ drinksDetail }: IDrinksDetailProps) {
+function MainDrinksDetail({ drinksDetail, drinksLike }: IDrinksDetailLike) {
   return (
     <MainDetailContainer>
-      <DrinksDetailItem drinksDetail={drinksDetail} />
+      <DrinksDetailItem drinksDetail={drinksDetail} drinksLike={drinksLike} />
       <DrinksDetailContent drinksDetail={drinksDetail} />
       <DrinksDetailComment drinksDetail={drinksDetail} />
     </MainDetailContainer>

--- a/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/DrinksDetailTxt.tsx
+++ b/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/DrinksDetailTxt.tsx
@@ -1,16 +1,16 @@
-import React from "react";
-import styled from "styled-components";
-import DrinksDetailBox from "./drinksdetailtxt/DrinksDetailBox";
-import DrinksDetailInfo from "./drinksdetailtxt/DrinksDetailInfo";
-import DrinksDetailTitle from "./drinksdetailtxt/DrinksDetailTitle";
-import { IDrinksDetailProps } from '../../../../util/interfaces/drinks.inerface'
+import React from 'react';
+import styled from 'styled-components';
+import DrinksDetailBox from './drinksdetailtxt/DrinksDetailBox';
+import DrinksDetailInfo from './drinksdetailtxt/DrinksDetailInfo';
+import DrinksDetailTitle from './drinksdetailtxt/DrinksDetailTitle';
+import { IDrinksDetailLike } from '../../../../util/interfaces/drinks.inerface';
 
-function DrinksDetailTxt({ drinksDetail }: IDrinksDetailProps) {
+function DrinksDetailTxt({ drinksDetail, drinksLike }: IDrinksDetailLike) {
   return (
     <TxtContainer>
       <DrinksDetailInfo drinksDetail={drinksDetail} />
       <DrinksDetailTitle drinksDetail={drinksDetail} />
-      <DrinksDetailBox drinksDetail={drinksDetail} />
+      <DrinksDetailBox drinksDetail={drinksDetail} drinksLike={drinksLike} />
     </TxtContainer>
   );
 }
@@ -28,12 +28,12 @@ const TxtContainer = styled.div`
   margin-left: var(--4x-large);
   padding: var(--medium) 0;
 
-    @media only screen and (max-width: 768px) {
-      width: 100%;
-      height: auto;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      margin: 0;
-    }
+  @media only screen and (max-width: 768px) {
+    width: 100%;
+    height: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 0;
+  }
 `;

--- a/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/drinksdetailtxt/DrinksDetailBox.tsx
+++ b/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/drinksdetailtxt/DrinksDetailBox.tsx
@@ -1,25 +1,28 @@
-import React from "react";
-import DrinksDetailLikes from "./drinksdetailbox/DrinksDetailLikes";
-import DrinksDetailTags from "./drinksdetailbox/DrinksDetailTags";
-import styled from "styled-components";
-import { Link } from "react-router-dom";
-import { IDrinksDetailProps } from '../../../../../util/interfaces/drinks.inerface'
-import DrinksDetailCount from "./drinksdetailbox/DrinksDetailCount";
+import React from 'react';
+import DrinksDetailLikes from './drinksdetailbox/DrinksDetailLikes';
+import DrinksDetailTags from './drinksdetailbox/DrinksDetailTags';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { IDrinksDetailLike } from '../../../../../util/interfaces/drinks.inerface';
+import DrinksDetailCount from './drinksdetailbox/DrinksDetailCount';
 
-function DrinksDetailBox({ drinksDetail }: IDrinksDetailProps) {
+function DrinksDetailBox({ drinksDetail, drinksLike }: IDrinksDetailLike) {
   return (
     <BoxContainer>
       <TagContainer>
-        {drinksDetail?.tags?.map(el => {
+        {drinksDetail?.tags?.map((el) => {
           return (
             <Link to={`/tags/${el.tagId}`} key={el.tagId}>
               <DrinksDetailTags tagName={el.tagName} />
             </Link>
-          )
+          );
         })}
       </TagContainer>
       <MarginContainer>
-        <DrinksDetailLikes drinksDetail={drinksDetail} />
+        <DrinksDetailLikes
+          drinksDetail={drinksDetail}
+          drinksLike={drinksLike}
+        />
       </MarginContainer>
       <DrinksDetailCount drinksDetail={drinksDetail} />
     </BoxContainer>
@@ -36,9 +39,9 @@ const BoxContainer = styled.div`
   justify-content: space-between;
 
   @media only screen and (max-width: 768px) {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
   }
 `;
 
@@ -48,10 +51,10 @@ const TagContainer = styled.div`
   justify-content: flex-start;
 
   @media only screen and (max-width: 768px) {
-  margin-bottom: var(--medium);
+    margin-bottom: var(--medium);
   }
-`
+`;
 
 const MarginContainer = styled.div`
   margin-right: var(--medium);
-`
+`;

--- a/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/drinksdetailtxt/drinksdetailbox/DrinksDetailLikes.tsx
+++ b/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/drinksdetailtxt/drinksdetailbox/DrinksDetailLikes.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { IoMdHeartEmpty, IoMdHeart } from 'react-icons/io';
-import { IDrinksDetailProps } from '../../../../../../util/interfaces/drinks.inerface';
+import { IDrinksDetailLike } from '../../../../../../util/interfaces/drinks.inerface';
 import { useAppSelector } from '../../../../../../redux/hooks/hooks';
 import { useNavigate } from 'react-router';
 
-function DrinksDetailLikes({ drinksDetail }: IDrinksDetailProps) {
+function DrinksDetailLikes({ drinksDetail, drinksLike }: IDrinksDetailLike) {
   const [likes, setlikes] = useState(false);
   const [login, setLogin] = useState(false);
+  const [count, setCount] = useState(0);
 
   const { isLogin } = useAppSelector((state) => state.auth);
 
@@ -15,11 +16,21 @@ function DrinksDetailLikes({ drinksDetail }: IDrinksDetailProps) {
 
   useEffect(() => {
     setLogin(isLogin);
-  }, [isLogin]);
+    if (drinksDetail) {
+      setCount(drinksDetail.likeCount);
+      setlikes(drinksLike);
+    }
+  }, [isLogin, drinksDetail, drinksLike]);
 
   const handleLikesChange = () => {
     if (login) {
-      setlikes((prev) => !prev);
+      if (likes) {
+        setCount((prev) => prev - 1);
+        setlikes(false);
+      } else {
+        setCount((prev) => prev + 1);
+        setlikes(true);
+      }
     } else {
       alert('로그인이 필요한 서비스입니다.');
       navigate('/signup');
@@ -33,7 +44,7 @@ function DrinksDetailLikes({ drinksDetail }: IDrinksDetailProps) {
       ) : (
         <IoMdHeartEmpty onClick={handleLikesChange} />
       )}
-      <span>{drinksDetail?.likeCount}</span>
+      <span>{count}</span>
     </LikesSize>
   );
 }

--- a/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/drinksdetailtxt/drinksdetailbox/DrinksDetailLikes.tsx
+++ b/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/drinksdetailtxt/drinksdetailbox/DrinksDetailLikes.tsx
@@ -4,6 +4,7 @@ import { IoMdHeartEmpty, IoMdHeart } from 'react-icons/io';
 import { IDrinksDetailLike } from '../../../../../../util/interfaces/drinks.inerface';
 import { useAppSelector } from '../../../../../../redux/hooks/hooks';
 import { useNavigate } from 'react-router';
+import customAxios from '../../../../../../api/customAxios';
 
 function DrinksDetailLikes({ drinksDetail, drinksLike }: IDrinksDetailLike) {
   const [likes, setlikes] = useState(false);
@@ -25,11 +26,21 @@ function DrinksDetailLikes({ drinksDetail, drinksLike }: IDrinksDetailLike) {
   const handleLikesChange = () => {
     if (login) {
       if (likes) {
-        setCount((prev) => prev - 1);
-        setlikes(false);
+        customAxios
+          .delete(`/likes/drinks/${drinksDetail?.drinkId}`)
+          .then((res) => {
+            setCount((prev) => prev - 1);
+            setlikes(false);
+          })
+          .catch((err) => console.log(Error, err));
       } else {
-        setCount((prev) => prev + 1);
-        setlikes(true);
+        customAxios
+          .post(`/likes/drinks/${drinksDetail?.drinkId}`)
+          .then((res) => {
+            setCount((prev) => prev + 1);
+            setlikes(true);
+          })
+          .catch((err) => console.log(Error, err));
       }
     } else {
       alert('로그인이 필요한 서비스입니다.');

--- a/client/src/pages/DrinksDetail.tsx
+++ b/client/src/pages/DrinksDetail.tsx
@@ -3,10 +3,12 @@ import { useParams } from 'react-router-dom';
 import customAxios from '../api/customAxios';
 import MainDrinksDetail from '../components/Drinks/DrinksDetail/MainDrinksDetail';
 import { IDrinksDetail } from '../util/interfaces/drinks.inerface';
+import { ILikes } from '../util/interfaces/drinks.inerface';
 
 function DrinksDetail() {
   const { drinkId } = useParams<{ drinkId: string }>();
   const [drinksDetail, setDrinksDetail] = useState<IDrinksDetail>();
+  const [drinksLike, setDrinksLike] = useState(false);
 
   useEffect(() => {
     const handleGetDrinksDetail = async () => {
@@ -18,10 +20,24 @@ function DrinksDetail() {
         console.error(error);
       }
     };
+    const handleGetDrinksLike = async () => {
+      try {
+        const res = await customAxios.get(`/drinks`);
+        const data = res.data.likeList?.some(
+          (drinkLike: ILikes) => drinkLike.drinkId === Number(drinkId)
+        );
+        setDrinksLike(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
     handleGetDrinksDetail();
+    handleGetDrinksLike();
   }, [drinkId]);
 
-  return <MainDrinksDetail drinksDetail={drinksDetail} />;
+  return (
+    <MainDrinksDetail drinksDetail={drinksDetail} drinksLike={drinksLike} />
+  );
 }
 
 export default DrinksDetail;

--- a/client/src/redux/slice/board/boardListSlice.ts
+++ b/client/src/redux/slice/board/boardListSlice.ts
@@ -37,7 +37,9 @@ export const boardListSlice = createSlice({
           ),
         };
       });
+
       state.likeList = likeList;
+
       const NotData = result.reduce((acc: BoardDataProps[], cur) => {
         let result: BoardDataProps[] = [...acc];
         if (
@@ -47,6 +49,7 @@ export const boardListSlice = createSlice({
         }
         return result;
       }, []);
+
       if (state.listData.length !== 0 && NotData.length !== 0) {
         state.listData = [...state.listData, ...NotData];
       } else if (state.listData.length === 0) {

--- a/client/src/util/interfaces/drinks.inerface.tsx
+++ b/client/src/util/interfaces/drinks.inerface.tsx
@@ -83,3 +83,8 @@ export interface IDrinksDetail {
 export interface IDrinksDetailProps {
   drinksDetail?: IDrinksDetail;
 }
+
+export interface IDrinksDetailLike {
+  drinksDetail?: IDrinksDetail;
+  drinksLike: boolean;
+}


### PR DESCRIPTION
## ✏️ Summary
- [x] Drinks Detail Page Like data 받아오기
- [x] Drinks Detail Page Like post 구현
- [x] Drinks Detail Page Like delete 구현


<br>

## 🔗 Describe your changes
![image](https://user-images.githubusercontent.com/115691844/229327652-b7b38172-523e-407d-b6b8-10fab38780b2.png)
![image](https://user-images.githubusercontent.com/115691844/229327662-35313706-494e-40fe-81ca-01544f7cc897.png)


<br>

## 💬 To Reviewers
- Drinks List Pages에서 Like를 눌러도 Drink Detail Page에 적용이 됩니다.
- Drink Detail Page에서 Like를 눌러도 Drinks List Pages에 적용이 됩니다.
