### PR TITLE
[FE] feat: 빈 Tag 클릭 시 결과 없음 페이지 반환

### DIFF
--- a/client/src/components/Drinks/DrinksDetail/DrinksDetailContent.tsx
+++ b/client/src/components/Drinks/DrinksDetail/DrinksDetailContent.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styled from "styled-components";
-import DrinksDetailSnacks from "./drinksdetailcontent/DrinksDetailSnacks";
-import DrinksDetailTasting from "./drinksdetailcontent/DrinksDetailTasting";
-import DrinksDetailWiths from "./drinksdetailcontent/DrinksDetailWiths";
+import DrinksDetailSnacks from "./drinksDetailContent/DrinksDetailSnacks";
+import DrinksDetailTasting from "./drinksDetailContent/DrinksDetailTasting";
+import DrinksDetailWiths from "./drinksDetailContent/DrinksDetailWiths";
 import { IDrinksDetailProps } from '../../../util/interfaces/drinks.inerface'
 
 function DrinksDetailContent({ drinksDetail }: IDrinksDetailProps) {

--- a/client/src/components/Drinks/DrinksDetail/DrinksDetailItem.tsx
+++ b/client/src/components/Drinks/DrinksDetail/DrinksDetailItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import DrinksDetailImg from './drinksdetaillitem/DrinksDetailImg';
-import DrinksDetailTxt from './drinksdetaillitem/DrinksDetailTxt';
+import DrinksDetailImg from './drinksDetaillItem/DrinksDetailImg';
+import DrinksDetailTxt from './drinksDetaillItem/DrinksDetailTxt';
 import { IDrinksDetailLike } from '../../../util/interfaces/drinks.inerface';
 
 function DrinksDetailItem({ drinksDetail, drinksLike }: IDrinksDetailLike) {

--- a/client/src/components/Drinks/DrinksDetail/drinksdetailcontent/DrinksDetailSnacks.tsx
+++ b/client/src/components/Drinks/DrinksDetail/drinksdetailcontent/DrinksDetailSnacks.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import DrinksDetailSnack from "./drinksdetailsnacks/DrinksDetailSnack";
-import DrinksDetailSnackTitle from "./drinksdetailsnacks/DrinksDetailSnackTitle";
+import DrinksDetailSnack from "./drinksDetailSnacks/DrinksDetailSnack";
+import DrinksDetailSnackTitle from "./drinksDetailSnacks/DrinksDetailSnackTitle";
 import styled from "styled-components";
 import { IDrinksDetailProps } from '../../../../util/interfaces/drinks.inerface'
 

--- a/client/src/components/Drinks/DrinksDetail/drinksdetailcontent/DrinksDetailTasting.tsx
+++ b/client/src/components/Drinks/DrinksDetail/drinksdetailcontent/DrinksDetailTasting.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import DrinksDetailChart from "./drinksdetailtasting/DrinksDetailChart";
-import DrinksDetailChartTitle from "./drinksdetailtasting/DrinksDetailChartTitle";
+import DrinksDetailChart from "./drinksDetailTasting/DrinksDetailChart";
+import DrinksDetailChartTitle from "./drinksDetailTasting/DrinksDetailChartTitle";
 import styled from "styled-components";
 import { IDrinksDetailProps } from '../../../../util/interfaces/drinks.inerface'
 

--- a/client/src/components/Drinks/DrinksDetail/drinksdetailcontent/DrinksDetailWiths.tsx
+++ b/client/src/components/Drinks/DrinksDetail/drinksdetailcontent/DrinksDetailWiths.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import DrinksDetailWith from "./drinksdetailwiths/DrinksDetailWith";
-import DrinksDetailWithTitle from "./drinksdetailwiths/DrinksDetailWithTitle";
+import DrinksDetailWith from "./drinksDetailWiths/DrinksDetailWith";
+import DrinksDetailWithTitle from "./drinksDetailWiths/DrinksDetailWithTitle";
 import { IDrinksDetailProps } from '../../../../util/interfaces/drinks.inerface'
 import { Link } from "react-router-dom";
 

--- a/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/DrinksDetailTxt.tsx
+++ b/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/DrinksDetailTxt.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import DrinksDetailBox from './drinksdetailtxt/DrinksDetailBox';
-import DrinksDetailInfo from './drinksdetailtxt/DrinksDetailInfo';
-import DrinksDetailTitle from './drinksdetailtxt/DrinksDetailTitle';
+import DrinksDetailBox from './drinksDetailTxt/DrinksDetailBox';
+import DrinksDetailInfo from './drinksDetailTxt/DrinksDetailInfo';
+import DrinksDetailTitle from './drinksDetailTxt/DrinksDetailTitle';
 import { IDrinksDetailLike } from '../../../../util/interfaces/drinks.inerface';
 
 function DrinksDetailTxt({ drinksDetail, drinksLike }: IDrinksDetailLike) {

--- a/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/drinksdetailtxt/DrinksDetailBox.tsx
+++ b/client/src/components/Drinks/DrinksDetail/drinksdetaillitem/drinksdetailtxt/DrinksDetailBox.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import DrinksDetailLikes from './drinksdetailbox/DrinksDetailLikes';
-import DrinksDetailTags from './drinksdetailbox/DrinksDetailTags';
+import DrinksDetailLikes from './drinksDetailBox/DrinksDetailLikes';
+import DrinksDetailTags from './drinksDetailBox/DrinksDetailTags';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { IDrinksDetailLike } from '../../../../../util/interfaces/drinks.inerface';
-import DrinksDetailCount from './drinksdetailbox/DrinksDetailCount';
+import DrinksDetailCount from './drinksDetailBox/DrinksDetailCount';
 
 function DrinksDetailBox({ drinksDetail, drinksLike }: IDrinksDetailLike) {
   return (

--- a/client/src/components/Drinks/DrinksList/DrinksContents.tsx
+++ b/client/src/components/Drinks/DrinksList/DrinksContents.tsx
@@ -7,7 +7,6 @@ import Pagination from "../../UI/Pagination";
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../redux/store/store'
 
-
 interface ISearchProps {
   search: string;
   searchTag: number;
@@ -24,46 +23,35 @@ function DrinksContents({ search, searchTag, page, setPage }: ISearchProps): any
   const offset = (page - 1) * limit;
 
   const { drinksData } = useSelector((state: RootState) => state.drinkslist);
+  const { tagData } = useSelector((state: RootState) => state.drinksTags);
 
   const drinkTagData: IDrinks[] = drinksData.filter((drink: Tags) => drink.tags.some(tag => tag.tagId === searchTag));
-  const drinkTagValue: number | null = drinkTagData.length > 0 ? drinkTagData[0].tags.find(tag => tag.tagId === searchTag)?.tagId ?? null : null;
-
-  const filteredDrinks = drinksData.filter((drink) => {
-    return search.toLowerCase() === "" ||
-      drink.drinkName.toLowerCase().includes(search.toLowerCase());
-  });
-
+  const filteredDrinks = drinksData.filter((drink) => search.toLowerCase() === "" || drink.drinkName.toLowerCase().includes(search.toLowerCase()));
   const displayedDrinks = filteredDrinks.slice(offset, offset + limit);
 
-  const drinksToShow = (searchTag === drinkTagValue)
-    ? drinkTagData.slice(offset, offset + limit)
-    : displayedDrinks;
+  const drinkTagValue = drinkTagData.length > 0 ? drinkTagData[0].tags.find(tag => tag.tagId === searchTag)?.tagId : null;
+  const drinksToShow = searchTag === drinkTagValue ? drinkTagData.slice(offset, offset + limit) : (searchTag !== 0 && drinkTagValue === null) ? [] : displayedDrinks;
+
+  /** Tag 클릭 시 해당하는 Tag가 Drinks에 없을 경우 div 반환 */
+  const text = tagData.find(item => item.tagId === searchTag)?.tagName;
 
   return (
     <ContentsContainer>
       {drinksToShow.length > 0 ? (
         <>
-          {drinksToShow.map((drink) => (
-            <DrinksItem key={drink.drinkId} drinksData={drink} />
-          ))}
-          {drinksToShow.length > 7 ?
+          {drinksToShow.map((drink) => <DrinksItem key={drink.drinkId} drinksData={drink} />)}
+          {drinksToShow.length > 7 && (
             <Pagination
-              total={
-                drinkTagData.length !== 0
-                  ? drinkTagData.length
-                  : filteredDrinks.length
-              }
+              total={drinkTagData.length || filteredDrinks.length}
               limit={limit}
               page={page}
               setPage={setPage}
               setLimit={setLimit}
-            /> : null}
-
+            />
+          )}
         </>
       ) : (
-        <div>
-          현재 페이지에서 '{search}'란 단어의 검색 결과가 없습니다.
-        </div>
+        <div>{drinkTagValue === null ? `현재 페이지에서 '${text}'의 검색 결과가 없습니다.` : `현재 페이지에서 '${search}'란 단어의 검색 결과가 없습니다.`}</div>
       )}
     </ContentsContainer>
   );

--- a/client/src/components/Drinks/DrinksList/DrinksContents.tsx
+++ b/client/src/components/Drinks/DrinksList/DrinksContents.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import DrinksItem from "./drinkscontent/DrinksItem";
+import DrinksItem from "./drinksContent/DrinksItem";
 import styled from "styled-components";
 import { IDrinks } from "../../../util/interfaces/drinks.inerface";
 import Pagination from "../../UI/Pagination";

--- a/client/src/components/Drinks/DrinksList/DrinksInfo.tsx
+++ b/client/src/components/Drinks/DrinksList/DrinksInfo.tsx
@@ -1,6 +1,6 @@
 import { useState, Dispatch, SetStateAction } from "react";
-import DrinksTagList from "./drinksinfo/DrinksTagList";
-import DrinkSearch from "./drinksinfo/DrinksSearch";
+import DrinksTagList from "./drinksInfo/DrinksTagList";
+import DrinkSearch from "./drinksInfo/DrinksSearch";
 import styled from "styled-components";
 import { AiOutlineSearch } from "react-icons/ai";
 import Button from "../../UI/Button";

--- a/client/src/components/Drinks/DrinksList/drinkscontent/DrinksItem.tsx
+++ b/client/src/components/Drinks/DrinksList/drinkscontent/DrinksItem.tsx
@@ -1,6 +1,6 @@
-import DrinksItemBox from "./drinksitem/DrinksItemBox";
-import DrinksItemBody from "./drinksitem/DrinksItemBody";
-import DrinksItemLevel from "./drinksitem/DrinksItemLevel";
+import DrinksItemBox from "./drinksItem/DrinksItemBox";
+import DrinksItemBody from "./drinksItem/DrinksItemBody";
+import DrinksItemLevel from "./drinksItem/DrinksItemLevel";
 import Card from "../../../UI/Card";
 import styled from "styled-components";
 import { Link } from "react-router-dom";

--- a/client/src/components/Drinks/DrinksList/drinkscontent/drinksitem/DrinksItemBox.tsx
+++ b/client/src/components/Drinks/DrinksList/drinkscontent/drinksitem/DrinksItemBox.tsx
@@ -1,5 +1,5 @@
-import DrinksLikes from "./drinksitembox/DrinksItemLikes";
-import DrinksItemTags from "./drinksitembox/DrinksItemTags";
+import DrinksLikes from "./drinksItemBox/DrinksItemLikes";
+import DrinksItemTags from "./drinksItemBox/DrinksItemTags";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { IDrinksProps } from "../../../../../util/interfaces/drinks.inerface";

--- a/client/src/components/Main/MainDrinksContent.tsx
+++ b/client/src/components/Main/MainDrinksContent.tsx
@@ -22,7 +22,6 @@ const MainContainer = styled.div`
   align-items: center;
 
   @media only screen and (max-width: 1024px) {
-    width: 80%;
     height: 100%;
     flex-direction: column;
     padding: var(--3x-large) 0;

--- a/client/src/components/Main/MainDrinksContent.tsx
+++ b/client/src/components/Main/MainDrinksContent.tsx
@@ -15,12 +15,11 @@ export default MainDrinksContent;
 
 const MainContainer = styled.div`
   max-width: 1420px;
-  width: 100%;
+  width: 85%;
   height: 50vh;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 0 30px;
 
   @media only screen and (max-width: 1024px) {
     width: 80%;

--- a/client/src/components/Main/MainTagsContent.tsx
+++ b/client/src/components/Main/MainTagsContent.tsx
@@ -15,13 +15,12 @@ export default MainTagsContent;
 
 const MainContainer = styled.div`
   max-width: 1420px;
-  width: 100%;
+  width: 85%;
   height: 50vh;
   display: flex;
   justify-content: center;
   align-items: center;
   background-color: var(--color-sub-light-gray);
-  padding: 0 30px;
 
   @media only screen and (max-width: 1024px) {
     width: 90%;

--- a/client/src/components/Main/MainTagsContent.tsx
+++ b/client/src/components/Main/MainTagsContent.tsx
@@ -23,7 +23,6 @@ const MainContainer = styled.div`
   background-color: var(--color-sub-light-gray);
 
   @media only screen and (max-width: 1024px) {
-    width: 90%;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -31,7 +30,6 @@ const MainContainer = styled.div`
   }
 
   @media only screen and (max-width: 768px) {
-    width: 90%;
     height: 100%;
     display: flex;
     flex-direction: column;

--- a/client/src/components/Main/MainTextContent.tsx
+++ b/client/src/components/Main/MainTextContent.tsx
@@ -19,7 +19,7 @@ const MainContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
+  width: 80%;
   height: 100vh;
   background-color: var(--color-sub-light-gray);
 

--- a/client/src/components/Main/MainTextContent.tsx
+++ b/client/src/components/Main/MainTextContent.tsx
@@ -24,12 +24,14 @@ const MainContainer = styled.div`
   background-color: var(--color-sub-light-gray);
 
   @media only screen and (max-width: 1024px) {
+  width: 80%;
     height: 100%;
     flex-direction: column;
     padding: var(--3x-large) 0;
   }
 
   @media only screen and (max-width: 768px) {
+  width: 80%;
     height: 100%;
     padding: var(--3x-large) 0;
   }

--- a/client/src/components/Tags/TagsDrinksContent.tsx
+++ b/client/src/components/Tags/TagsDrinksContent.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { useAppSelector } from '../../redux/hooks/hooks';
 
-import DrinksItem from '../Drinks/DrinksList/drinkscontent/DrinksItem';
+import DrinksItem from '../drinks/drinksList/drinksContent/DrinksItem';
 
 const TagsDrinksContent = () => {
   const drinksList = useAppSelector(state => state.tag.tagData.drink);

--- a/client/src/pages/DrinksDetail.tsx
+++ b/client/src/pages/DrinksDetail.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import customAxios from '../api/customAxios';
-import MainDrinksDetail from '../components/Drinks/DrinksDetail/MainDrinksDetail';
+import MainDrinksDetail from '../components/drinks/drinksDetail/MainDrinksDetail';
 import { IDrinksDetail } from '../util/interfaces/drinks.inerface';
 import { ILikes } from '../util/interfaces/drinks.inerface';
 

--- a/client/src/pages/DrinksList.tsx
+++ b/client/src/pages/DrinksList.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import MainDrinks from '../components/Drinks/DrinksList/MainDrinks'
+import MainDrinks from '../components/drinks/drinksList/MainDrinks'
 
 function DrinksList() {
   return (


### PR DESCRIPTION
## ✏️ Summary
- [x] Main Page 반응형 width 수정 (footer랑 padding값이 안 맞았었음)
- [x] drinks 폴더명 변경
- [x] Drinks List 빈 Tag 클릭 시 결과 없음 페이지 반환  



<br>

## 🔗 Describe your changes
<img width="1220" alt="image" src="https://user-images.githubusercontent.com/115635503/232436517-0cda939e-6599-4bcf-b823-ef0c1a471ff0.png">
<img width="198" alt="image" src="https://user-images.githubusercontent.com/115635503/232436789-fd609666-25d0-4d0e-85f7-0f9a4fd505ac.png">
<img width="751" alt="image" src="https://user-images.githubusercontent.com/115635503/232436894-611bda8b-adea-4c6f-a96f-0db640589ce4.png">



<br>

## 💬 To Reviewers
- 오류 없이 반영 되는지 확인하기 위해 drinks 먼저 수정했습니다. 내일 폴더명 전체적으로 수정하겠습니다.
