### PR TITLE
🐛 fix: board list search 버그 수정

### DIFF
--- a/client/src/components/board/boardList/BoardInfo.tsx
+++ b/client/src/components/board/boardList/BoardInfo.tsx
@@ -7,12 +7,12 @@ import { AiOutlineSearch } from 'react-icons/ai';
 import Button from '../../UI/Button';
 import { IBoardInfo } from '../../../util/interfaces/boards.interface';
 
-function BoardInfo({ isSearch, setIsLoading, setInput }: IBoardInfo) {
+function BoardInfo({ isSearch, setIsSearch, setInput }: IBoardInfo) {
   const [isInput, setIsInput] = useState('');
 
   const handleSearchChange = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    setIsLoading(isSearch ? false : true);
+    setIsSearch(isSearch ? false : true);
   };
 
   return (

--- a/client/src/pages/BoardList.tsx
+++ b/client/src/pages/BoardList.tsx
@@ -12,7 +12,7 @@ import Loading from '../components/UI/Loading';
 function BoardList() {
   const [page, setPage] = useState(1);
   const [endPage, setEndPage] = useState(1);
-  const [isSearch, setIsSearch] = useState(false);
+  const [isSearch, setIsSearch] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const [input, setInput] = useState('');
   const [ref, inView] = useInView();
@@ -66,7 +66,7 @@ function BoardList() {
         <Wrapper onClick={handleSearchClose}>
           <BoardInfo
             isSearch={isSearch}
-            setIsLoading={setIsLoading}
+            setIsSearch={setIsSearch}
             setInput={setInput}
           />
           <ListContainer>

--- a/client/src/util/interfaces/boards.interface.tsx
+++ b/client/src/util/interfaces/boards.interface.tsx
@@ -68,7 +68,7 @@ export interface ISetData {
 
 export interface IBoardInfo {
   isSearch: boolean;
-  setIsLoading: (state: boolean) => void;
+  setIsSearch: (state: boolean) => void;
   setInput: (state: string) => void;
 }
 


### PR DESCRIPTION
## ✏️ Summary
- board list search 버튼을 누를시 loding 페이지가 지속되는 버그 수정



<br>

## 🔗 Describe your changes
- 수정 전
![image](https://github.com/codestates-seb/seb42_main_001/assets/115691844/5046afa9-7600-4e5c-b257-fb14d3895c75)

- 수정 후
![image](https://github.com/codestates-seb/seb42_main_001/assets/115691844/72b13fba-83fa-4771-8a24-fd4aeac3482a)


<br>

## 💬 To Reviewers
- 상태를 수정하는 useState의 set함수를 setIsSearch로 작성해야하는 코드를 setIsLoding으로 작성하여 버튼을 누를때마다 로딩페이지로 전환되어 발생하는 버그였습니다. 
