### PR TITLE
[FE] fix: boardList 검색 시 없는 단어를 넣었을 때 깜빡거리는 현상 수정

### DIFF
--- a/client/src/components/board/boardList/BoardInfo.tsx
+++ b/client/src/components/board/boardList/BoardInfo.tsx
@@ -12,6 +12,8 @@ function BoardInfo({ isSearch, setIsSearch, setInput }: IBoardInfo) {
 
   const handleSearchChange = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+    setIsInput('');
+    setInput('');
     setIsSearch(isSearch ? false : true);
   };
 

--- a/client/src/pages/BoardList.tsx
+++ b/client/src/pages/BoardList.tsx
@@ -12,7 +12,7 @@ import Loading from '../components/UI/Loading';
 function BoardList() {
   const [page, setPage] = useState(1);
   const [endPage, setEndPage] = useState(1);
-  const [isSearch, setIsSearch] = useState(true);
+  const [isSearch, setIsSearch] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [input, setInput] = useState('');
   const [ref, inView] = useInView();

--- a/client/src/pages/BoardList.tsx
+++ b/client/src/pages/BoardList.tsx
@@ -49,7 +49,7 @@ function BoardList() {
       setTimeout(() => {
         setPage((prev) => prev + 1);
         timer.current = false;
-      }, 200);
+      }, 300);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inView]);
@@ -82,7 +82,9 @@ function BoardList() {
               })
             )}
           </ListContainer>
-          <RefContainer ref={ref} />
+          {filteredDatas.length !== 0 && !isSearch ? (
+            <RefContainer ref={ref} />
+          ) : null}
         </Wrapper>
       )}
     </>
@@ -101,7 +103,6 @@ const Wrapper = styled.div`
 `;
 
 const ListContainer = styled.div`
-  margin-bottom: calc(var(--4x-large));
   width: 100%;
   height: 100%;
   display: flex;
@@ -111,5 +112,6 @@ const ListContainer = styled.div`
 `;
 
 const RefContainer = styled.div`
-  height: 10vw;
+  height: 1vw;
+  margin-top: 20vh;
 `;


### PR DESCRIPTION
## ✏️ Summary
- boardList 첫 화면에서 검색 input이 활성화 되어있는 버그를 수정했습니다.
- boardList 검색 시 없는 단어를 넣었을 때 깜빡거리는 현상 수정했습니다.
- boardList 검색을 비활성화 할 경우 input 초기화 되는 기능 추가했습니다.



<br>

## 🔗 Describe your changes
-  input 초기화 되는 기능 추가 전
![image](https://github.com/codestates-seb/seb42_main_001/assets/115691844/dafccbab-ec3b-45f9-b2c6-cdec4ebdcea1)

- input 초기화 되는 기능 추가 후
![image](https://github.com/codestates-seb/seb42_main_001/assets/115691844/6f2a06c9-0212-4e7b-849b-b880fde68143)


<br>

## 💬 To Reviewers
- 첫 화면에서 검색 input이 활성화 되어있는 버그는 제가 저번 버그를 고치고 확인을 안하고 푸쉬를 하여 발생했습니다.
- 검색 시 없는 단어를 넣었을 때 깜빡거리는 현상은 react-observerAPI를 사용하여 무한 스크롤을 구현하였는데 board의 item의 개수가  적거나 없을 경우 자신이 화면에 보여졌을 때 함수를 호출해주는 요소가 노출되어 반복적으로 데이터 요청이 진행되어 나타나는 현상이었습니다. 그래서 board의 item의 개수가  적거나 없을 경우 자신이 화면에 보여졌을 때 함수를 호출해주는 요소를 노출하지 않는 방향으로 수정했습니다.
